### PR TITLE
alertlog changes

### DIFF
--- a/alertlog.go
+++ b/alertlog.go
@@ -1,153 +1,158 @@
 package main
 
 import (
-   "bufio"
-   "os"
-   "time"
-   "regexp"
-   "strings"
-   "strconv"
-   "github.com/prometheus/common/log"
+	"bufio"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/log"
 )
 
-
 type Client struct {
-  Ip string          `yaml:"ip"`
-  Date string        `yaml:"date"`
+	Ip   string `yaml:"ip"`
+	Date string `yaml:"date"`
 }
 
 type Lastlog struct {
-  Instance string    `yaml:"instance"`
-  Clients []Client   `yaml:"clients"`
+	Instance string   `yaml:"instance"`
+	Clients  []Client `yaml:"clients"`
 }
 
 type Lastlogs struct {
-  Cfgs []Lastlog     `yaml:"lastlog"`
+	Cfgs []Lastlog `yaml:"lastlog"`
 }
 
 type oraerr struct {
-  ora string
-  text string
-  ignore string
-  count int
+	ora    string
+	text   string
+	ignore string
+	count  int
 }
 
 var (
-  Errors      []oraerr
-  oralayout   = "Mon Jan 02 15:04:05 2006"
-  lastlog     Lastlogs
+	Errors    []oraerr
+	oralayout = "Mon Jan 02 15:04:05 2006"
+	lastlog   Lastlogs
 )
-
 
 // Get individual ScrapeTime per Prometheus instance for alertlog
 func (e *Exporter) GetLastScrapeTime(conf int) time.Time {
-  for i, _ := range lastlog.Cfgs {
-    if lastlog.Cfgs[i].Instance == config.Cfgs[conf].Instance {
-      for n, _ := range lastlog.Cfgs[i].Clients {
-        if lastlog.Cfgs[i].Clients[n].Ip == e.lastIp {
-          t, _ := time.Parse("2006-01-02 15:04:05 -0700 MST",string(lastlog.Cfgs[i].Clients[n].Date))
-          return t
-        }
-      }
-    }
-  }
-  return time.Now()
+	for i, _ := range lastlog.Cfgs {
+		if lastlog.Cfgs[i].Instance == config.Cfgs[conf].Instance {
+			for n, _ := range lastlog.Cfgs[i].Clients {
+				if lastlog.Cfgs[i].Clients[n].Ip == e.lastIp {
+					t, _ := time.Parse("2006-01-02 15:04:05 -0700 MST", string(lastlog.Cfgs[i].Clients[n].Date))
+					return t
+				}
+			}
+		}
+	}
+	return time.Now()
 }
 
 // Set individual ScrapeTime per Prometheus instance for alertlog
-func (e *Exporter) SetLastScrapeTime(conf int,t time.Time) {
-  var indInst int = -1
-  var indIp int = -1
-  for i, _ := range lastlog.Cfgs {
-    if lastlog.Cfgs[i].Instance == config.Cfgs[conf].Instance {
-      indInst = i
-      for n, _ := range lastlog.Cfgs[i].Clients {
-        if lastlog.Cfgs[i].Clients[n].Ip == e.lastIp {
-          indIp = n
-        }
-      }
-    }
-  }
-  if indInst == -1 {
-    cln := Client{Ip: e.lastIp, Date: t.Format("2006-01-02 15:04:05 -0700 MST")}
-    lastlog.Cfgs = append(lastlog.Cfgs, Lastlog{Instance: config.Cfgs[conf].Instance,
-                                                Clients:  []Client{ cln } } )
-  }else{
-    if indIp == -1 {
-      cln := Client{Ip: e.lastIp, Date: t.Format("2006-01-02 15:04:05 -0700 MST")}
-      lastlog.Cfgs[indInst].Clients = append(lastlog.Cfgs[indInst].Clients, cln)
-    }else{
-      lastlog.Cfgs[indInst].Clients[indIp].Date = t.Format("2006-01-02 15:04:05 -0700 MST")
-    }
-  }
+func (e *Exporter) SetLastScrapeTime(conf int, t time.Time) {
+	var indInst int = -1
+	var indIp int = -1
+	for i, _ := range lastlog.Cfgs {
+		if lastlog.Cfgs[i].Instance == config.Cfgs[conf].Instance {
+			indInst = i
+			for n, _ := range lastlog.Cfgs[i].Clients {
+				if lastlog.Cfgs[i].Clients[n].Ip == e.lastIp {
+					indIp = n
+				}
+			}
+		}
+	}
+	if indInst == -1 {
+		cln := Client{Ip: e.lastIp, Date: t.Format("2006-01-02 15:04:05 -0700 MST")}
+		lastlog.Cfgs = append(lastlog.Cfgs, Lastlog{Instance: config.Cfgs[conf].Instance,
+			Clients: []Client{cln}})
+	} else {
+		if indIp == -1 {
+			cln := Client{Ip: e.lastIp, Date: t.Format("2006-01-02 15:04:05 -0700 MST")}
+			lastlog.Cfgs[indInst].Clients = append(lastlog.Cfgs[indInst].Clients, cln)
+		} else {
+			lastlog.Cfgs[indInst].Clients[indIp].Date = t.Format("2006-01-02 15:04:05 -0700 MST")
+		}
+	}
 }
 
-func addError(conf int, ora string, text string){
-  var found bool = false
-  for i, _ := range Errors {
-    if Errors[i].ora == ora {
-      Errors[i].count ++
-      found = true
-    }
-  }
-  if ! found {
-    ignore := "0"
-    for _ , e := range config.Cfgs[conf].Alertlog[0].Ignoreora {
-      if e == ora {; ignore = "1"; }
-    }
-    is := strings.Index(text, " ")
-    ip := strings.Index(text, ". ")
-    if is < 0 {; is = 0; }
-    if ip < 0 {; ip = len(text); }
-    ora := oraerr{ora: ora, text: text[is+1:ip], ignore: ignore, count: 1}
-    Errors = append (Errors, ora)
-  }
+func addError(conf int, ora string, text string) {
+	var found bool = false
+	for i, _ := range Errors {
+		if Errors[i].ora == ora {
+			Errors[i].count++
+			found = true
+		}
+	}
+	if !found {
+		ignore := "0"
+		for _, e := range config.Cfgs[conf].Alertlog[0].Ignoreora {
+			if e == ora {
+				ignore = "1"
+			}
+		}
+		is := strings.Index(text, " ")
+		ip := strings.Index(text, ". ")
+		if is < 0 {
+			is = 0
+		}
+		if ip < 0 {
+			ip = len(text)
+		}
+		ora := oraerr{ora: ora, text: text[is+1 : ip], ignore: ignore, count: 1}
+		Errors = append(Errors, ora)
+	}
 }
 
 func (e *Exporter) ScrapeAlertlog() {
-  loc     := time.Now().Location()
-  re      := regexp.MustCompile(`O(RA|GG)-[0-9]+`)
+	loc := time.Now().Location()
+	re := regexp.MustCompile(`O(RA|GG)-[0-9]+`)
 
-  ReadAccess()
-  for conf, _ := range config.Cfgs {
-    var lastTime time.Time
-    Errors = nil
-    lastScrapeTime := e.GetLastScrapeTime(conf).Add(time.Second)
+	ReadAccess()
+	for conf, _ := range config.Cfgs {
+		var lastTime time.Time
+		Errors = nil
+		lastScrapeTime := e.GetLastScrapeTime(conf).Add(time.Second)
 
-    info, _ := os.Stat(config.Cfgs[conf].Alertlog[0].File)
-    file, err := os.Open(config.Cfgs[conf].Alertlog[0].File)
-    if err != nil {
-      log.Infoln(err)
-    } else{
-      scanner := bufio.NewScanner(file)
-      for scanner.Scan() {
-        t, err := time.ParseInLocation(oralayout, scanner.Text(),loc)
-        if err == nil {
-          lastTime = t
-        } else {
-          if lastTime.After(lastScrapeTime) {
-            if re.MatchString(scanner.Text()) {
-              ora := re.FindString(scanner.Text())
-              addError(conf,ora, scanner.Text())
-            }
-          }
-        }
-      }
-      file.Close()
-      e.SetLastScrapeTime(conf,lastTime)
-      for i, _ := range Errors {
-        e.alertlog.WithLabelValues(config.Cfgs[conf].Database,
-                                   config.Cfgs[conf].Instance,
-                                   Errors[i].ora,
-                                   Errors[i].text,
-                                   Errors[i].ignore).Set(float64(Errors[i].count))
-        WriteLog(config.Cfgs[conf].Instance + " " + e.lastIp +
-                 " (" + Errors[i].ignore + "/" + strconv.Itoa(Errors[i].count) + "): " +
-                 Errors[i].ora + " - " + Errors[i].text)
-      }
-      e.alertdate.WithLabelValues(config.Cfgs[conf].Database,
-                                  config.Cfgs[conf].Instance).Set(float64(info.ModTime().Unix()))
-    }
-  }
-  WriteAccess()
+		info, _ := os.Stat(config.Cfgs[conf].Alertlog[0].File)
+		file, err := os.Open(config.Cfgs[conf].Alertlog[0].File)
+		if err != nil {
+			log.Infoln(err)
+		} else {
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				t, err := time.ParseInLocation(oralayout, scanner.Text(), loc)
+				if err == nil {
+					lastTime = t
+				} else {
+					if lastTime.After(lastScrapeTime) {
+						if re.MatchString(scanner.Text()) {
+							ora := re.FindString(scanner.Text())
+							addError(conf, ora, scanner.Text())
+						}
+					}
+				}
+			}
+			file.Close()
+			e.SetLastScrapeTime(conf, lastTime)
+			for i, _ := range Errors {
+				e.alertlog.WithLabelValues(config.Cfgs[conf].Database,
+					config.Cfgs[conf].Instance,
+					Errors[i].ora,
+					Errors[i].text,
+					Errors[i].ignore).Set(float64(Errors[i].count))
+				WriteLog(config.Cfgs[conf].Instance + " " + e.lastIp +
+					" (" + Errors[i].ignore + "/" + strconv.Itoa(Errors[i].count) + "): " +
+					Errors[i].ora + " - " + Errors[i].text)
+			}
+			e.alertdate.WithLabelValues(config.Cfgs[conf].Database,
+				config.Cfgs[conf].Instance).Set(float64(info.ModTime().Unix()))
+		}
+	}
+	WriteAccess()
 }

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func NewExporter() *Exporter {
 			Namespace: namespace,
 			Name:      "error",
 			Help:      "Oracle Errors occured during configured interval.",
-		}, []string{"database", "dbinstance", "code", "description", "ignore"}),
+		}, []string{"database", "dbinstance", "code"}),
 		alertdate: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "error_unix_seconds",

--- a/main.go
+++ b/main.go
@@ -1,68 +1,69 @@
 package main
 
 import (
-    "database/sql"
-    "flag"
-    "net"
-    "net/http"
-    "time"
-  _ "github.com/mattn/go-oci8"
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/common/log"
+	"database/sql"
+	"flag"
+	"net"
+	"net/http"
+	"time"
+
+	_ "github.com/mattn/go-oci8"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 // Metric name parts.
 const (
-  namespace = "oracledb"
-  exporter  = "exporter"
+	namespace = "oracledb"
+	exporter  = "exporter"
 )
 
 // Exporter collects Oracle DB metrics. It implements prometheus.Collector.
 type Exporter struct {
-  duration, error prometheus.Gauge
-  totalScrapes    prometheus.Counter
-  scrapeErrors    *prometheus.CounterVec
-  session         *prometheus.GaugeVec
-  sysstat         *prometheus.GaugeVec
-  waitclass       *prometheus.GaugeVec
-  sysmetric       *prometheus.GaugeVec
-  interconnect    *prometheus.GaugeVec
-  uptime          *prometheus.GaugeVec
-  up              *prometheus.GaugeVec
-  tablespace      *prometheus.GaugeVec
-  recovery        *prometheus.GaugeVec
-  redo            *prometheus.GaugeVec
-  cache           *prometheus.GaugeVec
-  alertlog        *prometheus.GaugeVec
-  alertdate       *prometheus.GaugeVec
-  services        *prometheus.GaugeVec
-  parameter       *prometheus.GaugeVec
-  query           *prometheus.GaugeVec
-  asmspace        *prometheus.GaugeVec
-  tablerows       *prometheus.GaugeVec
-  tablebytes      *prometheus.GaugeVec
-  indexbytes      *prometheus.GaugeVec
-  lobbytes        *prometheus.GaugeVec
-  lastIp          string
-  vTabRows        bool
-  vTabBytes       bool
-  vIndBytes       bool
-  vLobBytes       bool
+	duration, error prometheus.Gauge
+	totalScrapes    prometheus.Counter
+	scrapeErrors    *prometheus.CounterVec
+	session         *prometheus.GaugeVec
+	sysstat         *prometheus.GaugeVec
+	waitclass       *prometheus.GaugeVec
+	sysmetric       *prometheus.GaugeVec
+	interconnect    *prometheus.GaugeVec
+	uptime          *prometheus.GaugeVec
+	up              *prometheus.GaugeVec
+	tablespace      *prometheus.GaugeVec
+	recovery        *prometheus.GaugeVec
+	redo            *prometheus.GaugeVec
+	cache           *prometheus.GaugeVec
+	alertlog        *prometheus.GaugeVec
+	alertdate       *prometheus.GaugeVec
+	services        *prometheus.GaugeVec
+	parameter       *prometheus.GaugeVec
+	query           *prometheus.GaugeVec
+	asmspace        *prometheus.GaugeVec
+	tablerows       *prometheus.GaugeVec
+	tablebytes      *prometheus.GaugeVec
+	indexbytes      *prometheus.GaugeVec
+	lobbytes        *prometheus.GaugeVec
+	lastIp          string
+	vTabRows        bool
+	vTabBytes       bool
+	vIndBytes       bool
+	vLobBytes       bool
 }
 
 var (
-  // Version will be set at build time.
-  Version       = "1.1.0"
-  listenAddress = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
-  metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-  pTabRows      = flag.Bool("tablerows", false, "Expose Table rows (CAN TAKE VERY LONG)")
-  pTabBytes     = flag.Bool("tablebytes", false, "Expose Table size (CAN TAKE VERY LONG)")
-  pIndBytes     = flag.Bool("indexbytes", false, "Expose Index size for any Table (CAN TAKE VERY LONG)")
-  pLobBytes     = flag.Bool("lobbytes", false, "Expose Lobs size for any Table (CAN TAKE VERY LONG)")
-  configFile    = flag.String("configfile", "oracle.conf", "ConfigurationFile in YAML format.")
-  logFile       = flag.String("logfile", "exporter.log", "Logfile for parsed Oracle Alerts.")
-  accessFile    = flag.String("accessfile", "access.conf", "Last access for parsed Oracle Alerts.")
-  landingPage   = []byte(`<html>
+	// Version will be set at build time.
+	Version       = "1.1.0"
+	listenAddress = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
+	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	pTabRows      = flag.Bool("tablerows", false, "Expose Table rows (CAN TAKE VERY LONG)")
+	pTabBytes     = flag.Bool("tablebytes", false, "Expose Table size (CAN TAKE VERY LONG)")
+	pIndBytes     = flag.Bool("indexbytes", false, "Expose Index size for any Table (CAN TAKE VERY LONG)")
+	pLobBytes     = flag.Bool("lobbytes", false, "Expose Lobs size for any Table (CAN TAKE VERY LONG)")
+	configFile    = flag.String("configfile", "oracle.conf", "ConfigurationFile in YAML format.")
+	logFile       = flag.String("logfile", "exporter.log", "Logfile for parsed Oracle Alerts.")
+	accessFile    = flag.String("accessfile", "access.conf", "Last access for parsed Oracle Alerts.")
+	landingPage   = []byte(`<html>
                           <head><title>Prometheus Oracle exporter</title></head>
                           <body>
                             <h1>Prometheus Oracle exporter</h1><p>
@@ -77,377 +78,373 @@ var (
 
 // NewExporter returns a new Oracle DB exporter for the provided DSN.
 func NewExporter() *Exporter {
-  return &Exporter{
-    duration: prometheus.NewGauge(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "last_scrape_duration_seconds",
-      Help:      "Duration of the last scrape of metrics from Oracle DB.",
-    }),
-    totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "scrapes_total",
-      Help:      "Total number of times Oracle DB was scraped for metrics.",
-    }),
-    scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "scrape_errors_total",
-      Help:      "Total number of times an error occured scraping a Oracle database.",
-    }, []string{"collector"}),
-    error: prometheus.NewGauge(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "last_scrape_error",
-      Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
-    }),
-    sysmetric: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "sysmetric",
-      Help:      "Gauge metric with read/write pysical IOPs/bytes (v$sysmetric).",
-    }, []string{"database","dbinstance","type"}),
-    waitclass: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "waitclass",
-      Help:      "Gauge metric with Waitevents (v$waitclassmetric).",
-    }, []string{"database","dbinstance","type"}),
-    sysstat: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "sysstat",
-      Help:      "Gauge metric with commits/rollbacks/parses (v$sysstat).",
-    }, []string{"database","dbinstance","type"}),
-    session: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "session",
-      Help:      "Gauge metric user/system active/passive sessions (v$session).",
-    }, []string{"database","dbinstance","type","state"}),
-    uptime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "uptime",
-      Help:      "Gauge metric with uptime in days of the Instance.",
-    }, []string{"database","dbinstance"}),
-    tablespace: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "tablespace",
-      Help:      "Gauge metric with total/free size of the Tablespaces.",
-    }, []string{"database","dbinstance","type","name","contents","autoextend"}),
-    interconnect: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "interconnect",
-      Help:      "Gauge metric with interconnect block transfers (v$sysstat).",
-    }, []string{"database","dbinstance","type"}),
-    recovery: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "recovery",
-      Help:      "Gauge metric with percentage usage of FRA (v$recovery_file_dest).",
-    }, []string{"database","dbinstance","type"}),
-    redo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "redo",
-      Help:      "Gauge metric with Redo log switches over last 5 min (v$log_history).",
-    }, []string{"database","dbinstance"}),
-    cache: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "cachehitratio",
-      Help:      "Gauge metric witch Cache hit ratios (v$sysmetric).",
-    }, []string{"database","dbinstance","type"}),
-    up: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "up",
-      Help:      "Whether the Oracle server is up.",
-    }, []string{"database","dbinstance"}),
-    alertlog: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "error",
-      Help:      "Oracle Errors occured during configured interval.",
-    }, []string{"database","dbinstance","code","description","ignore"}),
-    alertdate: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "error_unix_seconds",
-      Help:      "Unixtime of Alertlog modified Date.",
-    }, []string{"database","dbinstance"}),
-    services: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "services",
-      Help:      "Active Oracle Services (v$active_services).",
-    }, []string{"database","dbinstance","name"}),
-    parameter: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "parameter",
-      Help:      "oracle Configuration Parameters (v$parameter).",
-    }, []string{"database","dbinstance","name"}),
-    query: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "query",
-      Help:      "Self defined Queries from Configuration File.",
-    }, []string{"database","dbinstance","name"}),
-    asmspace: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "asmspace",
-      Help:      "Gauge metric with total/free size of the ASM Diskgroups.",
-    }, []string{"database","dbinstance","type","name"}),
-      tablerows: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "tablerows",
-      Help:      "Gauge metric with rows of all Tables.",
-    }, []string{"database","dbinstance","owner","table_name","tablespace"}),
-    tablebytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "tablebytes",
-      Help:      "Gauge metric with bytes of all Tables.",
-    }, []string{"database","dbinstance","owner","table_name"}),
-    indexbytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "indexbytes",
-      Help:      "Gauge metric with bytes of all Indexes per Table.",
-    }, []string{"database","dbinstance","owner","table_name"}),
-    lobbytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "lobbytes",
-      Help:      "Gauge metric with bytes of all Lobs per Table.",
-    }, []string{"database","dbinstance","owner","table_name"}),
-  }
+	return &Exporter{
+		duration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_duration_seconds",
+			Help:      "Duration of the last scrape of metrics from Oracle DB.",
+		}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrapes_total",
+			Help:      "Total number of times Oracle DB was scraped for metrics.",
+		}),
+		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrape_errors_total",
+			Help:      "Total number of times an error occured scraping a Oracle database.",
+		}, []string{"collector"}),
+		error: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_error",
+			Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
+		}),
+		sysmetric: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "sysmetric",
+			Help:      "Gauge metric with read/write pysical IOPs/bytes (v$sysmetric).",
+		}, []string{"database", "dbinstance", "type"}),
+		waitclass: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "waitclass",
+			Help:      "Gauge metric with Waitevents (v$waitclassmetric).",
+		}, []string{"database", "dbinstance", "type"}),
+		sysstat: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "sysstat",
+			Help:      "Gauge metric with commits/rollbacks/parses (v$sysstat).",
+		}, []string{"database", "dbinstance", "type"}),
+		session: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "session",
+			Help:      "Gauge metric user/system active/passive sessions (v$session).",
+		}, []string{"database", "dbinstance", "type", "state"}),
+		uptime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "uptime",
+			Help:      "Gauge metric with uptime in days of the Instance.",
+		}, []string{"database", "dbinstance"}),
+		tablespace: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "tablespace",
+			Help:      "Gauge metric with total/free size of the Tablespaces.",
+		}, []string{"database", "dbinstance", "type", "name", "contents", "autoextend"}),
+		interconnect: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "interconnect",
+			Help:      "Gauge metric with interconnect block transfers (v$sysstat).",
+		}, []string{"database", "dbinstance", "type"}),
+		recovery: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "recovery",
+			Help:      "Gauge metric with percentage usage of FRA (v$recovery_file_dest).",
+		}, []string{"database", "dbinstance", "type"}),
+		redo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "redo",
+			Help:      "Gauge metric with Redo log switches over last 5 min (v$log_history).",
+		}, []string{"database", "dbinstance"}),
+		cache: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "cachehitratio",
+			Help:      "Gauge metric witch Cache hit ratios (v$sysmetric).",
+		}, []string{"database", "dbinstance", "type"}),
+		up: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "up",
+			Help:      "Whether the Oracle server is up.",
+		}, []string{"database", "dbinstance"}),
+		alertlog: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "error",
+			Help:      "Oracle Errors occured during configured interval.",
+		}, []string{"database", "dbinstance", "code", "description", "ignore"}),
+		alertdate: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "error_unix_seconds",
+			Help:      "Unixtime of Alertlog modified Date.",
+		}, []string{"database", "dbinstance"}),
+		services: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "services",
+			Help:      "Active Oracle Services (v$active_services).",
+		}, []string{"database", "dbinstance", "name"}),
+		parameter: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "parameter",
+			Help:      "oracle Configuration Parameters (v$parameter).",
+		}, []string{"database", "dbinstance", "name"}),
+		query: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "query",
+			Help:      "Self defined Queries from Configuration File.",
+		}, []string{"database", "dbinstance", "name"}),
+		asmspace: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "asmspace",
+			Help:      "Gauge metric with total/free size of the ASM Diskgroups.",
+		}, []string{"database", "dbinstance", "type", "name"}),
+		tablerows: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "tablerows",
+			Help:      "Gauge metric with rows of all Tables.",
+		}, []string{"database", "dbinstance", "owner", "table_name", "tablespace"}),
+		tablebytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "tablebytes",
+			Help:      "Gauge metric with bytes of all Tables.",
+		}, []string{"database", "dbinstance", "owner", "table_name"}),
+		indexbytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "indexbytes",
+			Help:      "Gauge metric with bytes of all Indexes per Table.",
+		}, []string{"database", "dbinstance", "owner", "table_name"}),
+		lobbytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "lobbytes",
+			Help:      "Gauge metric with bytes of all Lobs per Table.",
+		}, []string{"database", "dbinstance", "owner", "table_name"}),
+	}
 }
 
 // ScrapeQuery collects metrics from self defined queries from configuration file.
 func (e *Exporter) ScrapeQuery() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    //num  metric_name
-    //43  sessions
-    if conn.db != nil {
-      for _, query := range conn.Queries {
-        rows, err = conn.db.Query(query.Sql)
-        if err != nil {
-          break
-        }
-        defer rows.Close()
-        for rows.Next() {
-          var value float64
-          if err := rows.Scan(&value); err != nil {
-            break
-          }
-          e.query.WithLabelValues(conn.Database,conn.Instance,query.Name).Set(value)
-        }
-      }
-    }
-  }
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		//num  metric_name
+		//43  sessions
+		if conn.db != nil {
+			for _, query := range conn.Queries {
+				rows, err = conn.db.Query(query.Sql)
+				if err != nil {
+					break
+				}
+				defer rows.Close()
+				for rows.Next() {
+					var value float64
+					if err := rows.Scan(&value); err != nil {
+						break
+					}
+					e.query.WithLabelValues(conn.Database, conn.Instance, query.Name).Set(value)
+				}
+			}
+		}
+	}
 }
 
 // ScrapeParameters collects metrics from the v$parameters view.
 func (e *Exporter) ScrapeParameter() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    //num  metric_name
-    //43  sessions
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select name,value from v$parameter WHERE num=43`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name,&value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.parameter.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		//num  metric_name
+		//43  sessions
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select name,value from v$parameter WHERE num=43`)
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.parameter.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
-
 
 // ScrapeServices collects metrics from the v$active_services view.
 func (e *Exporter) ScrapeServices() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select name from v$active_services`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        if err := rows.Scan(&name); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.services.WithLabelValues(conn.Database,conn.Instance,name).Set(1)
-      }
-    }
-  }
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select name from v$active_services`)
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				if err := rows.Scan(&name); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.services.WithLabelValues(conn.Database, conn.Instance, name).Set(1)
+			}
+		}
+	}
 }
-
 
 // ScrapeCache collects session metrics from the v$sysmetrics view.
 func (e *Exporter) ScrapeCache() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    //metric_id  metric_name
-    //2000    Buffer Cache Hit Ratio
-    //2050    Cursor Cache Hit Ratio
-    //2112    Library Cache Hit Ratio
-    //2110    Row Cache Hit Ratio
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select metric_name,value
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		//metric_id  metric_name
+		//2000    Buffer Cache Hit Ratio
+		//2050    Cursor Cache Hit Ratio
+		//2112    Library Cache Hit Ratio
+		//2110    Row Cache Hit Ratio
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select metric_name,value
                                  from v$sysmetric
                                  where group_id=2 and metric_id in (2000,2050,2112,2110)`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.cache.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.cache.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
-
 
 // ScrapeRecovery collects tablespace metrics
 func (e *Exporter) ScrapeRedo() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select count(*) from v$log_history where first_time > sysdate - 1/24/12`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var value float64
-        if err := rows.Scan(&value); err != nil {
-          break
-        }
-        e.redo.WithLabelValues(conn.Database,conn.Instance).Set(value)
-      }
-    }
-  }
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select count(*) from v$log_history where first_time > sysdate - 1/24/12`)
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var value float64
+				if err := rows.Scan(&value); err != nil {
+					break
+				}
+				e.redo.WithLabelValues(conn.Database, conn.Instance).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeRecovery collects tablespace metrics
 func (e *Exporter) ScrapeRecovery() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT sum(percent_space_used) , sum(percent_space_reclaimable)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT sum(percent_space_used) , sum(percent_space_reclaimable)
                                  from V$FLASH_RECOVERY_AREA_USAGE`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var used float64
-        var recl float64
-        if err := rows.Scan(&used, &recl); err != nil {
-          break
-        }
-        e.recovery.WithLabelValues(conn.Database,conn.Instance,"percent_space_used").Set(used)
-        e.recovery.WithLabelValues(conn.Database,conn.Instance,"percent_space_reclaimable").Set(recl)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var used float64
+				var recl float64
+				if err := rows.Scan(&used, &recl); err != nil {
+					break
+				}
+				e.recovery.WithLabelValues(conn.Database, conn.Instance, "percent_space_used").Set(used)
+				e.recovery.WithLabelValues(conn.Database, conn.Instance, "percent_space_reclaimable").Set(recl)
+			}
+		}
+	}
 }
 
 // ScrapeTablespaces collects tablespace metrics
 func (e *Exporter) ScrapeInterconnect() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT name, value
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT name, value
                                  FROM V$SYSSTAT
                                  WHERE name in ('gc cr blocks served','gc cr blocks flushed','gc cr blocks received')`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.interconnect.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.interconnect.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeAsmspace collects ASM metrics
 func (e *Exporter) ScrapeAsmspace() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT g.name, sum(d.total_mb), sum(d.free_mb)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT g.name, sum(d.total_mb), sum(d.free_mb)
                                   FROM v$asm_disk d, v$asm_diskgroup g
                                  WHERE  d.group_number = g.group_number (+)
                                   AND  d.header_status = 'MEMBER'
                                  GROUP by  g.name,  g.group_number`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var tsize float64
-        var tfree float64
-        if err := rows.Scan(&name, &tsize, &tfree); err != nil {
-          break
-        }
-        e.asmspace.WithLabelValues(conn.Database,conn.Instance,"total",name).Set(tsize)
-        e.asmspace.WithLabelValues(conn.Database,conn.Instance,"free",name).Set(tfree)
-        e.asmspace.WithLabelValues(conn.Database,conn.Instance,"used",name).Set(tsize-tfree)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var tsize float64
+				var tfree float64
+				if err := rows.Scan(&name, &tsize, &tfree); err != nil {
+					break
+				}
+				e.asmspace.WithLabelValues(conn.Database, conn.Instance, "total", name).Set(tsize)
+				e.asmspace.WithLabelValues(conn.Database, conn.Instance, "free", name).Set(tfree)
+				e.asmspace.WithLabelValues(conn.Database, conn.Instance, "used", name).Set(tsize - tfree)
+			}
+		}
+	}
 }
-
 
 // ScrapeTablespaces collects tablespace metrics
 func (e *Exporter) ScrapeTablespace() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`WITH
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`WITH
                                    getsize AS (SELECT tablespace_name, autoextensible, SUM(bytes) tsize
                                                FROM dba_data_files GROUP BY tablespace_name, autoextensible),
                                    getfree as (SELECT tablespace_name, contents, SUM(blocks*block_size) tfree
@@ -461,491 +458,497 @@ func (e *Exporter) ScrapeTablespace() {
                                  SELECT tablespace_name, 'TEMPORARY', sum(tablespace_size), sum(free_space), 'NO'
                                  FROM dba_temp_free_space
                                  GROUP BY tablespace_name`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var contents string
-        var tsize float64
-        var tfree float64
-        var auto string
-        if err := rows.Scan(&name, &contents, &tsize, &tfree, &auto); err != nil {
-          break
-        }
-        e.tablespace.WithLabelValues(conn.Database,conn.Instance,"total",name,contents,auto).Set(tsize)
-        e.tablespace.WithLabelValues(conn.Database,conn.Instance,"free",name,contents,auto).Set(tfree)
-        e.tablespace.WithLabelValues(conn.Database,conn.Instance,"used",name,contents,auto).Set(tsize-tfree)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var contents string
+				var tsize float64
+				var tfree float64
+				var auto string
+				if err := rows.Scan(&name, &contents, &tsize, &tfree, &auto); err != nil {
+					break
+				}
+				e.tablespace.WithLabelValues(conn.Database, conn.Instance, "total", name, contents, auto).Set(tsize)
+				e.tablespace.WithLabelValues(conn.Database, conn.Instance, "free", name, contents, auto).Set(tfree)
+				e.tablespace.WithLabelValues(conn.Database, conn.Instance, "used", name, contents, auto).Set(tsize - tfree)
+			}
+		}
+	}
 }
 
 // ScrapeSessions collects session metrics from the v$session view.
 func (e *Exporter) ScrapeSession() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT decode(username,NULL,'SYSTEM','SYS','SYSTEM','USER'), status,count(*)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT decode(username,NULL,'SYSTEM','SYS','SYSTEM','USER'), status,count(*)
                                  FROM v$session
                                  GROUP BY decode(username,NULL,'SYSTEM','SYS','SYSTEM','USER'),status`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var user string
-        var status string
-        var value float64
-        if err := rows.Scan(&user, &status, &value); err != nil {
-          break
-        }
-        e.session.WithLabelValues(conn.Database,conn.Instance,user,status).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var user string
+				var status string
+				var value float64
+				if err := rows.Scan(&user, &status, &value); err != nil {
+					break
+				}
+				e.session.WithLabelValues(conn.Database, conn.Instance, user, status).Set(value)
+			}
+		}
+	}
 }
-
 
 // ScrapeUptime Instance uptime
 func (e *Exporter) ScrapeUptime() {
-  var uptime float64
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      err := conn.db.QueryRow("select sysdate-startup_time from v$instance").Scan(&uptime)
-      if err != nil {
-        return
-      }
-      e.uptime.WithLabelValues(conn.Database,conn.Instance).Set(uptime)
-    }
-  }
+	var uptime float64
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			err := conn.db.QueryRow("select sysdate-startup_time from v$instance").Scan(&uptime)
+			if err != nil {
+				return
+			}
+			e.uptime.WithLabelValues(conn.Database, conn.Instance).Set(uptime)
+		}
+	}
 }
 
 // ScrapeSysstat collects activity metrics from the v$sysstat view.
 func (e *Exporter) ScrapeSysstat() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT name, value FROM v$sysstat
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT name, value FROM v$sysstat
                                     WHERE statistic# in (6,7,1084,1089)`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.sysstat.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.sysstat.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeWaitTime collects wait time metrics from the v$waitclassmetric view.
 func (e *Exporter) ScrapeWaitclass() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT n.wait_class, round(m.time_waited/m.INTSIZE_CSEC,3)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT n.wait_class, round(m.time_waited/m.INTSIZE_CSEC,3)
                                     FROM v$waitclassmetric  m, v$system_wait_class n
                                     WHERE m.wait_class_id=n.wait_class_id and n.wait_class != 'Idle'`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.waitclass.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.waitclass.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeSysmetrics collects session metrics from the v$sysmetrics view.
 func (e *Exporter) ScrapeSysmetric() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    //metric_id  metric_name
-    //2092    Physical Read Total IO Requests Per Sec
-    //2093    Physical Read Total Bytes Per Sec
-    //2100    Physical Write Total IO Requests Per Sec
-    //2124    Physical Write Total Bytes Per Sec
-    if conn.db != nil {
-      rows, err = conn.db.Query("select metric_name,value from v$sysmetric where metric_id in (2092,2093,2124,2100)")
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var name string
-        var value float64
-        if err := rows.Scan(&name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.sysmetric.WithLabelValues(conn.Database,conn.Instance,name).Set(value)
-      }
-    }
-  }
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		//metric_id  metric_name
+		//2092    Physical Read Total IO Requests Per Sec
+		//2093    Physical Read Total Bytes Per Sec
+		//2100    Physical Write Total IO Requests Per Sec
+		//2124    Physical Write Total Bytes Per Sec
+		if conn.db != nil {
+			rows, err = conn.db.Query("select metric_name,value from v$sysmetric where metric_id in (2092,2093,2124,2100)")
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				var value float64
+				if err := rows.Scan(&name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.sysmetric.WithLabelValues(conn.Database, conn.Instance, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeTablerows collects bytes from dba_tables view.
 func (e *Exporter) ScrapeTablerows() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select owner,table_name, tablespace_name, num_rows
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select owner,table_name, tablespace_name, num_rows
                                  from dba_tables
                                  where owner not like '%SYS%' and num_rows is not null`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var owner string
-        var name string
-        var space string
-        var value float64
-        if err := rows.Scan(&owner, &name, &space, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.tablerows.WithLabelValues(conn.Database,conn.Instance,owner,name,space).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var owner string
+				var name string
+				var space string
+				var value float64
+				if err := rows.Scan(&owner, &name, &space, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.tablerows.WithLabelValues(conn.Database, conn.Instance, owner, name, space).Set(value)
+			}
+		}
+	}
 }
 
 func (e *Exporter) ScrapeTablebytes() {
-  // ScrapeTablebytes collects bytes from dba_tables/dba_segments view.
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`SELECT tab.owner, tab.table_name,  stab.bytes
+	// ScrapeTablebytes collects bytes from dba_tables/dba_segments view.
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`SELECT tab.owner, tab.table_name,  stab.bytes
                                  FROM dba_tables  tab, dba_segments stab
                                  WHERE stab.owner = tab.owner AND stab.segment_name = tab.table_name
                                  AND tab.owner NOT LIKE '%SYS%'`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var owner string
-        var name string
-        var value float64
-        if err = rows.Scan(&owner, &name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.tablebytes.WithLabelValues(conn.Database,conn.Instance,owner,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var owner string
+				var name string
+				var value float64
+				if err = rows.Scan(&owner, &name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.tablebytes.WithLabelValues(conn.Database, conn.Instance, owner, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeTablebytes collects bytes from dba_indexes/dba_segments view.
 func (e *Exporter) ScrapeIndexbytes() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select table_owner,table_name, sum(bytes)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select table_owner,table_name, sum(bytes)
                                  from dba_indexes ind, dba_segments seg
                                  WHERE ind.owner=seg.owner and ind.index_name=seg.segment_name
                                  and table_owner NOT LIKE '%SYS%'
                                  group by table_owner,table_name`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var owner string
-        var name string
-        var value float64
-        if err = rows.Scan(&owner, &name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.indexbytes.WithLabelValues(conn.Database,conn.Instance,owner,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var owner string
+				var name string
+				var value float64
+				if err = rows.Scan(&owner, &name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.indexbytes.WithLabelValues(conn.Database, conn.Instance, owner, name).Set(value)
+			}
+		}
+	}
 }
 
 // ScrapeLobbytes collects bytes from dba_lobs/dba_segments view.
 func (e *Exporter) ScrapeLobbytes() {
-  var (
-    rows *sql.Rows
-    err  error
-  )
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      rows, err = conn.db.Query(`select l.owner, l.table_name, sum(bytes)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			rows, err = conn.db.Query(`select l.owner, l.table_name, sum(bytes)
                                  from dba_lobs l, dba_segments seg
                                  WHERE l.owner=seg.owner and l.table_name=seg.segment_name
                                  and l.owner NOT LIKE '%SYS%'
                                  group by l.owner,l.table_name`)
-      if err != nil {
-        break
-      }
-      defer rows.Close()
-      for rows.Next() {
-        var owner string
-        var name string
-        var value float64
-        if err = rows.Scan(&owner, &name, &value); err != nil {
-          break
-        }
-        name = cleanName(name)
-        e.lobbytes.WithLabelValues(conn.Database,conn.Instance,owner,name).Set(value)
-      }
-    }
-  }
+			if err != nil {
+				break
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var owner string
+				var name string
+				var value float64
+				if err = rows.Scan(&owner, &name, &value); err != nil {
+					break
+				}
+				name = cleanName(name)
+				e.lobbytes.WithLabelValues(conn.Database, conn.Instance, owner, name).Set(value)
+			}
+		}
+	}
 }
 
 // Describe describes all the metrics exported by the Oracle exporter.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-  e.duration.Describe(ch)
-  e.totalScrapes.Describe(ch)
-  e.scrapeErrors.Describe(ch)
-  e.session.Describe(ch)
-  e.sysstat.Describe(ch)
-  e.waitclass.Describe(ch)
-  e.sysmetric.Describe(ch)
-  e.interconnect.Describe(ch)
-  e.tablespace.Describe(ch)
-  e.recovery.Describe(ch)
-  e.redo.Describe(ch)
-  e.cache.Describe(ch)
-  e.uptime.Describe(ch)
-  e.up.Describe(ch)
-  e.alertlog.Describe(ch)
-  e.alertdate.Describe(ch)
-  e.services.Describe(ch)
-  e.parameter.Describe(ch)
-  e.query.Describe(ch)
-  e.asmspace.Describe(ch)
-  e.tablerows.Describe(ch)
-  e.tablebytes.Describe(ch)
-  e.indexbytes.Describe(ch)
-  e.lobbytes.Describe(ch)
+	e.duration.Describe(ch)
+	e.totalScrapes.Describe(ch)
+	e.scrapeErrors.Describe(ch)
+	e.session.Describe(ch)
+	e.sysstat.Describe(ch)
+	e.waitclass.Describe(ch)
+	e.sysmetric.Describe(ch)
+	e.interconnect.Describe(ch)
+	e.tablespace.Describe(ch)
+	e.recovery.Describe(ch)
+	e.redo.Describe(ch)
+	e.cache.Describe(ch)
+	e.uptime.Describe(ch)
+	e.up.Describe(ch)
+	e.alertlog.Describe(ch)
+	e.alertdate.Describe(ch)
+	e.services.Describe(ch)
+	e.parameter.Describe(ch)
+	e.query.Describe(ch)
+	e.asmspace.Describe(ch)
+	e.tablerows.Describe(ch)
+	e.tablebytes.Describe(ch)
+	e.indexbytes.Describe(ch)
+	e.lobbytes.Describe(ch)
 }
 
 // Connect the DBs and gather Databasename and Instancename
 func (e *Exporter) Connect() {
-  var dbname string
-  var inname string
-  var err error
+	var dbname string
+	var inname string
+	var err error
 
-  for i, conf := range config.Cfgs {
-    // Close Connect from former scrape that not closed properly
-    if config.Cfgs[i].db != nil {
-       config.Cfgs[i].db.Close()
-       config.Cfgs[i].db = nil
-    }
-    config.Cfgs[i].db , err = sql.Open("oci8", conf.Connection)
-    if err == nil {
-      err = config.Cfgs[i].db.QueryRow("select db_unique_name,instance_name from v$database,v$instance").Scan(&dbname,&inname)
-      if err == nil {
-        if (conf.Database != dbname) || (conf.Instance != inname) {
-          config.Cfgs[i].Database = dbname
-          config.Cfgs[i].Instance = inname
-        }
-        e.up.WithLabelValues(conf.Database,conf.Instance).Set(1)
-      } else {
-        config.Cfgs[i].db.Close()
-        config.Cfgs[i].db = nil;
-        e.up.WithLabelValues(conf.Database,conf.Instance).Set(0)
-        log.Infoln("Connect OK, Inital query failed: ", conf.Connection)
-      }
-    } else {
-      e.up.WithLabelValues(conf.Database,conf.Instance).Set(0)
-    }
-  }
-  e.session.Reset()
-  e.sysstat.Reset()
-  e.waitclass.Reset()
-  e.sysmetric.Reset()
-  e.interconnect.Reset()
-  e.tablespace.Reset()
-  e.recovery.Reset()
-  e.redo.Reset()
-  e.cache.Reset()
-  e.uptime.Reset()
-  e.alertlog.Reset()
-  e.alertdate.Reset()
-  e.services.Reset()
-  e.parameter.Reset()
-  e.query.Reset()
-  e.asmspace.Reset()
-  e.tablerows.Reset()
-  e.tablebytes.Reset()
-  e.indexbytes.Reset()
-  e.lobbytes.Reset()
+	for i, conf := range config.Cfgs {
+		// Close Connect from former scrape that not closed properly
+		if config.Cfgs[i].db != nil {
+			config.Cfgs[i].db.Close()
+			config.Cfgs[i].db = nil
+		}
+		config.Cfgs[i].db, err = sql.Open("oci8", conf.Connection)
+		if err == nil {
+			err = config.Cfgs[i].db.QueryRow("select db_unique_name,instance_name from v$database,v$instance").Scan(&dbname, &inname)
+			if err == nil {
+				if (conf.Database != dbname) || (conf.Instance != inname) {
+					config.Cfgs[i].Database = dbname
+					config.Cfgs[i].Instance = inname
+				}
+				e.up.WithLabelValues(conf.Database, conf.Instance).Set(1)
+			} else {
+				config.Cfgs[i].db.Close()
+				config.Cfgs[i].db = nil
+				e.up.WithLabelValues(conf.Database, conf.Instance).Set(0)
+				log.Infoln("Connect OK, Inital query failed: ", conf.Connection)
+			}
+		} else {
+			e.up.WithLabelValues(conf.Database, conf.Instance).Set(0)
+		}
+	}
+	e.session.Reset()
+	e.sysstat.Reset()
+	e.waitclass.Reset()
+	e.sysmetric.Reset()
+	e.interconnect.Reset()
+	e.tablespace.Reset()
+	e.recovery.Reset()
+	e.redo.Reset()
+	e.cache.Reset()
+	e.uptime.Reset()
+	e.alertlog.Reset()
+	e.alertdate.Reset()
+	e.services.Reset()
+	e.parameter.Reset()
+	e.query.Reset()
+	e.asmspace.Reset()
+	e.tablerows.Reset()
+	e.tablebytes.Reset()
+	e.indexbytes.Reset()
+	e.lobbytes.Reset()
 }
 
 // Close Connections
 func (e *Exporter) Close() {
-  for _, conn := range config.Cfgs {
-    if conn.db != nil {
-      conn.db.Close()
-      conn.db = nil
-    }
-  }
+	for _, conn := range config.Cfgs {
+		if conn.db != nil {
+			conn.db.Close()
+			conn.db = nil
+		}
+	}
 }
-
 
 // Collect implements prometheus.Collector.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-  var err error
+	var err error
 
-  e.totalScrapes.Inc()
-  defer func(begun time.Time) {
-    e.duration.Set(time.Since(begun).Seconds())
-    if err == nil {
-      e.error.Set(0)
-    } else {
-      e.error.Set(1)
-    }
-  }(time.Now())
+	e.totalScrapes.Inc()
+	defer func(begun time.Time) {
+		e.duration.Set(time.Since(begun).Seconds())
+		if err == nil {
+			e.error.Set(0)
+		} else {
+			e.error.Set(1)
+		}
+	}(time.Now())
 
-  e.Connect()
-  e.up.Collect(ch)
+	e.Connect()
+	e.up.Collect(ch)
 
-  e.ScrapeUptime()
-  e.uptime.Collect(ch)
+	e.ScrapeUptime()
+	e.uptime.Collect(ch)
 
-  e.ScrapeSession()
-  e.session.Collect(ch)
+	e.ScrapeSession()
+	e.session.Collect(ch)
 
-  e.ScrapeSysstat()
-  e.sysstat.Collect(ch)
+	e.ScrapeSysstat()
+	e.sysstat.Collect(ch)
 
-  e.ScrapeWaitclass()
-  e.waitclass.Collect(ch)
+	e.ScrapeWaitclass()
+	e.waitclass.Collect(ch)
 
-  e.ScrapeSysmetric()
-  e.sysmetric.Collect(ch)
+	e.ScrapeSysmetric()
+	e.sysmetric.Collect(ch)
 
-  e.ScrapeTablespace()
-  e.tablespace.Collect(ch)
+	e.ScrapeTablespace()
+	e.tablespace.Collect(ch)
 
-  e.ScrapeInterconnect()
-  e.interconnect.Collect(ch)
+	e.ScrapeInterconnect()
+	e.interconnect.Collect(ch)
 
-  e.ScrapeRecovery()
-  e.recovery.Collect(ch)
+	e.ScrapeRecovery()
+	e.recovery.Collect(ch)
 
-  e.ScrapeRedo()
-  e.redo.Collect(ch)
+	e.ScrapeRedo()
+	e.redo.Collect(ch)
 
-  e.ScrapeCache()
-  e.cache.Collect(ch)
+	e.ScrapeCache()
+	e.cache.Collect(ch)
 
-  e.ScrapeAlertlog()
-  e.alertlog.Collect(ch)
-  e.alertdate.Collect(ch)
+	e.ScrapeAlertlog()
+	e.alertlog.Collect(ch)
+	e.alertdate.Collect(ch)
 
-  e.ScrapeServices()
-  e.services.Collect(ch)
+	e.ScrapeServices()
+	e.services.Collect(ch)
 
-  e.ScrapeParameter()
-  e.parameter.Collect(ch)
+	e.ScrapeParameter()
+	e.parameter.Collect(ch)
 
-  e.ScrapeQuery()
-  e.query.Collect(ch)
+	e.ScrapeQuery()
+	e.query.Collect(ch)
 
-  e.ScrapeAsmspace()
-  e.asmspace.Collect(ch)
+	e.ScrapeAsmspace()
+	e.asmspace.Collect(ch)
 
-  if e.vTabRows || *pTabRows {
-    e.ScrapeTablerows()
-    e.tablerows.Collect(ch)
-  }
+	if e.vTabRows || *pTabRows {
+		e.ScrapeTablerows()
+		e.tablerows.Collect(ch)
+	}
 
-  if e.vTabBytes || *pTabBytes {
-    e.ScrapeTablebytes()
-    e.tablebytes.Collect(ch)
-  }
+	if e.vTabBytes || *pTabBytes {
+		e.ScrapeTablebytes()
+		e.tablebytes.Collect(ch)
+	}
 
-  if e.vIndBytes || *pIndBytes {
-    e.ScrapeIndexbytes()
-    e.indexbytes.Collect(ch)
-  }
+	if e.vIndBytes || *pIndBytes {
+		e.ScrapeIndexbytes()
+		e.indexbytes.Collect(ch)
+	}
 
-  if e.vLobBytes || *pLobBytes {
-    e.ScrapeLobbytes()
-    e.lobbytes.Collect(ch)
-  }
+	if e.vLobBytes || *pLobBytes {
+		e.ScrapeLobbytes()
+		e.lobbytes.Collect(ch)
+	}
 
-  ch <- e.duration
-  ch <- e.totalScrapes
-  ch <- e.error
-  e.scrapeErrors.Collect(ch)
+	ch <- e.duration
+	ch <- e.totalScrapes
+	ch <- e.error
+	e.scrapeErrors.Collect(ch)
 
-  e.Close()
+	e.Close()
 }
 
 func (e *Exporter) Handler(w http.ResponseWriter, r *http.Request) {
-  e.lastIp = ""
-  ip, _, err := net.SplitHostPort(r.RemoteAddr)
-  if err == nil {
-    e.lastIp = ip
-  }
-  e.vTabRows  = false
-  e.vTabBytes = false
-  e.vIndBytes = false
-  e.vLobBytes = false
-  if r.URL.Query().Get("tablerows") == "true" {; e.vTabRows = true; }
-  if r.URL.Query().Get("tablebytes") == "true" {; e.vTabBytes = true; }
-  if r.URL.Query().Get("indexbytes") == "true" {; e.vIndBytes = true; }
-  if r.URL.Query().Get("lobbytes") == "true" {; e.vLobBytes = true; }
-  prometheus.Handler().ServeHTTP(w, r)
+	e.lastIp = ""
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		e.lastIp = ip
+	}
+	e.vTabRows = false
+	e.vTabBytes = false
+	e.vIndBytes = false
+	e.vLobBytes = false
+	if r.URL.Query().Get("tablerows") == "true" {
+		e.vTabRows = true
+	}
+	if r.URL.Query().Get("tablebytes") == "true" {
+		e.vTabBytes = true
+	}
+	if r.URL.Query().Get("indexbytes") == "true" {
+		e.vIndBytes = true
+	}
+	if r.URL.Query().Get("lobbytes") == "true" {
+		e.vLobBytes = true
+	}
+	prometheus.Handler().ServeHTTP(w, r)
 }
 
 func main() {
-  flag.Parse()
-  log.Infoln("Starting Prometheus Oracle exporter " + Version)
-  if loadConfig() {
-    log.Infoln("Config loaded: ", *configFile)
-    exporter := NewExporter()
-    prometheus.MustRegister(exporter)
+	flag.Parse()
+	log.Infoln("Starting Prometheus Oracle exporter " + Version)
+	if loadConfig() {
+		log.Infoln("Config loaded: ", *configFile)
+		exporter := NewExporter()
+		prometheus.MustRegister(exporter)
 
-    http.HandleFunc(*metricPath, exporter.Handler)
+		http.HandleFunc(*metricPath, exporter.Handler)
 
-    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {w.Write(landingPage)})
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.Write(landingPage) })
 
-    log.Infoln("Listening on", *listenAddress)
-    log.Fatal(http.ListenAndServe(*listenAddress, nil))
-  }
+		log.Infoln("Listening on", *listenAddress)
+		log.Fatal(http.ListenAndServe(*listenAddress, nil))
+	}
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ type Exporter struct {
 
 var (
 	// Version will be set at build time.
-	Version       = "1.1.0"
+	Version       = "2.0.0"
 	listenAddress = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
 	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	pTabRows      = flag.Bool("tablerows", false, "Expose Table rows (CAN TAKE VERY LONG)")

--- a/misc.go
+++ b/misc.go
@@ -1,102 +1,103 @@
 package main
 
 import (
-    "os"
-    "time"
-    "strings"
-    "io/ioutil"
-    "gopkg.in/yaml.v2"
-    "path/filepath"
-    "database/sql"
-    "github.com/prometheus/common/log"
-  _ "github.com/mattn/go-oci8"
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-oci8"
+	"github.com/prometheus/common/log"
+	"gopkg.in/yaml.v2"
 )
 
 type Alert struct {
-  File string        `yaml:"file"`
-  Ignoreora []string `yaml:"ignoreora"`
+	File      string   `yaml:"file"`
+	Ignoreora []string `yaml:"ignoreora"`
 }
 
 type Query struct {
-  Sql string         `yaml:"sql"`
-  Name string        `yaml:"name"`
+	Sql  string `yaml:"sql"`
+	Name string `yaml:"name"`
 }
 
 type Config struct {
-  Connection string  `yaml:"connection"`
-  Database string    `yaml:"database"`
-  Instance string    `yaml:"instance"`
-  Alertlog []Alert   `yaml:"alertlog"`
-  Queries []Query    `yaml:"queries"`
-  db                 *sql.DB
+	Connection string  `yaml:"connection"`
+	Database   string  `yaml:"database"`
+	Instance   string  `yaml:"instance"`
+	Alertlog   []Alert `yaml:"alertlog"`
+	Queries    []Query `yaml:"queries"`
+	db         *sql.DB
 }
 
 type Configs struct {
-  Cfgs []Config `yaml:"connections"`
+	Cfgs []Config `yaml:"connections"`
 }
 
 var (
-   config        Configs
-   pwd           string
+	config Configs
+	pwd    string
 )
 
 // Oracle gives us some ugly names back. This function cleans things up for Prometheus.
 func cleanName(s string) string {
-  s = strings.Replace(s, " ", "_", -1) // Remove spaces
-  s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
-  s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
-  s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
-  s = strings.ToLower(s)
-  return s
+	s = strings.Replace(s, " ", "_", -1) // Remove spaces
+	s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
+	s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
+	s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
+	s = strings.ToLower(s)
+	return s
 }
 
 func cleanIp(s string) string {
-  s = strings.Replace(s, ":", "", -1) // Remove spaces
-  s = strings.Replace(s, ".", "_", -1)  // Remove open parenthesis
-  return s
+	s = strings.Replace(s, ":", "", -1)  // Remove spaces
+	s = strings.Replace(s, ".", "_", -1) // Remove open parenthesis
+	return s
 }
 
 func loadConfig() bool {
-  path, err := filepath.Abs(filepath.Dir(os.Args[0]))
-  if err != nil {
-    log.Fatalf("error: %v", err)
-  }
-  pwd = path
-  content, err := ioutil.ReadFile(*configFile)
-  if err != nil {
-      log.Fatalf("error: %v", err)
-      return false
-  } else {
-    err := yaml.Unmarshal(content, &config)
-    if err != nil {
-      log.Fatalf("error: %v", err)
-      return false
-    }
-    return true
-  }
+	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	pwd = path
+	content, err := ioutil.ReadFile(*configFile)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+		return false
+	} else {
+		err := yaml.Unmarshal(content, &config)
+		if err != nil {
+			log.Fatalf("error: %v", err)
+			return false
+		}
+		return true
+	}
 }
 
-func ReadAccess(){
-  var file = pwd + "/" + *accessFile
-  content, err := ioutil.ReadFile(file)
-  if err == nil {
-    err := yaml.Unmarshal(content, &lastlog)
-    if err != nil {
-      log.Fatalf("error1: %v", err)
-    }
-  }
+func ReadAccess() {
+	var file = pwd + "/" + *accessFile
+	content, err := ioutil.ReadFile(file)
+	if err == nil {
+		err := yaml.Unmarshal(content, &lastlog)
+		if err != nil {
+			log.Fatalf("error1: %v", err)
+		}
+	}
 }
 
-func WriteAccess(){
-  content, _ := yaml.Marshal(&lastlog)
-  ioutil.WriteFile(pwd + "/" + *accessFile, content, 0644)
+func WriteAccess() {
+	content, _ := yaml.Marshal(&lastlog)
+	ioutil.WriteFile(pwd+"/"+*accessFile, content, 0644)
 }
 
 func WriteLog(message string) {
-  fh, err := os.OpenFile(pwd + "/" + *logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-  if err == nil {
-    fh.Seek(0,2)
-    fh.WriteString(time.Now().Format("2006-01-02 15:04:05") + " " + message + "\n")
-    fh.Close()
-  }
+	fh, err := os.OpenFile(pwd+"/"+*logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err == nil {
+		fh.Seek(0, 2)
+		fh.WriteString(time.Now().Format("2006-01-02 15:04:05") + " " + message + "\n")
+		fh.Close()
+	}
 }

--- a/misc.go
+++ b/misc.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Alert struct {
-	File      string   `yaml:"file"`
-	Ignoreora []string `yaml:"ignoreora"`
+	File   string   `yaml:"file"`
+	Ignore []string `yaml:"Ignore"`
+	Ogg    bool     `yaml:"ogg"`
 }
 
 type Query struct {
@@ -97,11 +98,14 @@ func WriteAccess() {
 	ioutil.WriteFile(normalizePath(*accessFile), content, 0644)
 }
 
-func WriteLog(message string) {
+func WriteLog(message string) bool {
 	fh, err := os.OpenFile(normalizePath(*logFile), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err == nil {
-		fh.Seek(0, 2)
-		fh.WriteString(time.Now().Format("2006-01-02 15:04:05") + " " + message + "\n")
-		fh.Close()
+	if err != nil {
+		log.Infof("Failed writing to a log, %v", err)
+		return false
 	}
+	fh.Seek(0, 2)
+	fh.WriteString(time.Now().Format("2006-01-02 15:04:05") + " " + message + "\n")
+	fh.Close()
+	return true
 }

--- a/oracle.conf.example
+++ b/oracle.conf.example
@@ -4,16 +4,28 @@ connections:
    instance: DEVELOP
    alertlog:
     - file: /data/oracle/diag/rdbms/develop/DEVELOP/trace/alert_DEVELOP.log
-      ignoreora:
-       - ORA-00001
-       - ORA-01033
-       - ORA-01041
-       - ORA-01089
-       - ORA-01555
-       - ORA-28
-       - ORA-235
-       - ORA-609
-       - ORA-3136
+      ignore:
+        - ORA-00001
+        - ORA-01033
+        - ORA-01041
+        - ORA-01089
+        - ORA-01555
+        - ORA-28
+        - ORA-235
+        - ORA-609
+        - ORA-3136
+    - file: /u01/app/oracle/product/12.1.0/gg_12201/ggserr.log
+      ogg: true
+      ignore:
+        - ORA-00001
+        - ORA-01033
+        - ORA-01041
+        - ORA-01089
+        - ORA-01555
+        - ORA-28
+        - ORA-235
+        - ORA-609
+        - ORA-3136
    queries:
     - sql: "select 1 from dual"
       name: sample1
@@ -25,7 +37,7 @@ connections:
    instance: STAGE
    alertlog:
     - file: /data/oracle/diag/rdbms/stage/STAGE/trace/alert_STAGE.log
-      ignoreora:
+      Ignore:
       - ORA-00001
       - ORA-01033
       - ORA-01041

--- a/oracle.conf.example
+++ b/oracle.conf.example
@@ -17,15 +17,9 @@ connections:
     - file: /u01/app/oracle/product/12.1.0/gg_12201/ggserr.log
       ogg: true
       ignore:
-        - ORA-00001
-        - ORA-01033
-        - ORA-01041
-        - ORA-01089
-        - ORA-01555
-        - ORA-28
-        - ORA-235
-        - ORA-609
-        - ORA-3136
+        - OGG-123
+        - OGG-456
+        - OGG-789
    queries:
     - sql: "select 1 from dual"
       name: sample1

--- a/oracle.conf.example
+++ b/oracle.conf.example
@@ -31,7 +31,7 @@ connections:
    instance: STAGE
    alertlog:
     - file: /data/oracle/diag/rdbms/stage/STAGE/trace/alert_STAGE.log
-      Ignore:
+      ignore:
       - ORA-00001
       - ORA-01033
       - ORA-01041


### PR DESCRIPTION
I am not sure if you will accept this PR as it introduces some changes which you may not want but here it is anyway

- can now parse GoldenGate logs for OGG-123 type errors
- can now parse multiple log files
- normalised paths to files passed as options to the binary
- removed "description" field from the exported metric
- removed "ignore" field as well and instead errors listed to be ignored in the config file are actually ignored and not exported
- renamed ignoreora option to ignore (as it wont be always ORA but OGG as well)
- added ogg option to config file
