### PR TITLE
Update alertlog.go

### DIFF
--- a/alertlog.go
+++ b/alertlog.go
@@ -7,8 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/prometheus/common/log"
+	"log"
 )
 
 type Client struct {

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/mattn/go-oci8"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
+	"log"
 )
 
 // Metric name parts.


### PR DESCRIPTION
log is deprecated, instead log needs to point to common log package